### PR TITLE
fix(fbvuln): Create fbvuln-manifest directories if needed

### DIFF
--- a/classes/fbvuln-manifest.bbclass
+++ b/classes/fbvuln-manifest.bbclass
@@ -203,6 +203,13 @@ python fbvuln_track_write_manifest () {
                 except ValueError as ve:
                     bb.warn('{}'.format(ve))
 
+        if manifest_name:
+            manifest_dir = manifest_name.rsplit('/',1)
+            if manifest_dir:
+                manifest_dir = manifest_dir[0]
+                if not os.path.exists(manifest_dir):
+                    os.makedirs(manifest_dir)
+
         with open(manifest_name, 'w') as ofh:
             for pn in sorted(vulns.keys()):
                 meta = vulns[pn]


### PR DESCRIPTION
The release builds are built with INHERIT += "fbvuln-manifest" because we want to create the CVE manifest from the fbvuln-manifest.bbclass file. However at some point e2e-image stopped building this way and it was not discovered until release time.  This is because the build order of this particular target starts creating manifests before the deploy directory has been created.  Fix this by creating the directory if needed in fbvuln-manifest.bbclass.