### PR TITLE
fbvuln: support new override syntax

### DIFF
--- a/classes/fbvuln-manifest.bbclass
+++ b/classes/fbvuln-manifest.bbclass
@@ -132,10 +132,12 @@ python fbvuln_track_write_manifest () {
                     pkgmap[pkg] = dn
                     p = os.path.join(d.getVar("PKGDATA_DIR"), 'runtime', pkg)
                     needle = 'PKG_%s: ' % pkg
+                    needle2 = 'PKG:%s: ' % pkg
                     if os.path.isfile(p):
                         with open(p, 'r') as f:
                             for line in f:
-                                if not line.startswith(needle):
+                                if not line.startswith(needle) and \
+                                        not line.startswith(needle2):
                                     continue
                                 for rpkg in line[len(needle):].strip().split():
                                     pkgmap[rpkg] = dn
@@ -231,7 +233,7 @@ python fbvuln_track_write_manifest () {
         bb.debug(2, "Image vulnerability manifest saved to: %s" % manifest_name)
 }
 
-IMAGE_POSTPROCESS_COMMAND_prepend = "${@'fbvuln_track_write_manifest; '}"
+IMAGE_POSTPROCESS_COMMAND:prepend = "${@'fbvuln_track_write_manifest; '}"
 do_image_complete[recrdeptask] += "${@'do_fbvuln_track'}"
 
 def _scan_patch_file(f, matchers):


### PR DESCRIPTION
The master branch of Yocto (and the upcoming honister release) has a new
override syntax which changes '_' to ':', such as VARIABLE_prepend
switches to VARAIBLE:prepend.  Yocto versions as far back as Dunfell
were backported with support for this by automatically changing ':' back
to '_' in attempts to maintain backwards compatibility.  I have also
further backported these patches to Rocko and Zeus to support legacy
builds on some Facebook OpenBMC machines.

Ran the automatic conversion script provided by upstream poky on this
meta-layer: scripts/contrib/convert-overrides.py.  Observed that one of
the changes performed by this script ('needle' search) would not work on
older Yocto versions, since they still emit "PKG_" into the pkgdata
files, so I slightly modified the search to handle both characters.

Signed-off-by: Patrick Williams <patrick@stwcx.xyz>
