### PR TITLE
[meta-fbvuln] fbvuln-manifest.bbclass kirkstone variable name change

### DIFF
--- a/classes/fbvuln-manifest.bbclass
+++ b/classes/fbvuln-manifest.bbclass
@@ -68,7 +68,7 @@
 #   bitbake core-image-minimal
 CVE_PRODUCT ??= "${BPN}"
 CVE_VERSION ??= "${PV}"
-CVE_CHECK_WHITELIST ??= ""
+CVE_CHECK_IGNORE ??= "${CVE_CHECK_WHITELIST}"
 FBVULN_EXCUDE_RECIPE ??= "0"
 
 FBVULN_CHECK_TMP_FILE ?= "${TMPDIR}/fbvuln.tmp"
@@ -263,7 +263,7 @@ def get_patches_vulns(d):
 
     patched_cves = set()
     bb.debug(2, "Looking for patches that solves CVEs for %s" % pn)
-    for ca in d.getVar("CVE_CHECK_WHITELIST").split():
+    for ca in d.getVar("CVE_CHECK_IGNORE").split():
         bb.debug(2, "Adding prepatched CVE %s for %s" % (ca, pn))
         patched_cves.add(ca)
 


### PR DESCRIPTION
Summary: for kirkstone release the variable name `CVE_CHECK_WHITELIST` became `CVE_CHECK_IGNORE`

Test Plan: run sandcastle job using canary command. This job will make the changes to file and run `lf-obmc update-branch` and lf-obmc download-mirror`
