### PR TITLE
Support Scarthgap CVE_STATUS

### DIFF
--- a/classes/fbvuln-manifest.bbclass
+++ b/classes/fbvuln-manifest.bbclass
@@ -68,7 +68,6 @@
 #   bitbake core-image-minimal
 CVE_PRODUCT ??= "${BPN}"
 CVE_VERSION ??= "${PV}"
-CVE_CHECK_IGNORE ??= "${CVE_CHECK_WHITELIST}"
 FBVULN_EXCUDE_RECIPE ??= "0"
 
 FBVULN_CHECK_TMP_FILE ?= "${TMPDIR}/fbvuln.tmp"
@@ -263,7 +262,19 @@ def get_patches_vulns(d):
 
     patched_cves = set()
     bb.debug(2, "Looking for patches that solves CVEs for %s" % pn)
-    for ca in d.getVar("CVE_CHECK_IGNORE").split():
+
+    # Before Kirkstone, CVE_CHECK_WHITELIST contained the CVE fixes.
+    for ca in (d.getVar("CVE_CHECK_WHITELIST") or "").split():
+        bb.debug(2, "Adding prepatched CVE %s for %s" % (ca, pn))
+        patched_cves.add(ca)
+
+    # Before Scarthgap, CVE_CHECK_IGNORE contained the CVE fixes.
+    for ca in (d.getVar("CVE_CHECK_IGNORE") or "").split():
+        bb.debug(2, "Adding prepatched CVE %s for %s" % (ca, pn))
+        patched_cves.add(ca)
+
+    # With Scarthgap, CVE_STATUS also contains the CVE fixes.
+    for ca in (d.getVarFlags("CVE_STATUS") or {}).keys():
         bb.debug(2, "Adding prepatched CVE %s for %s" % (ca, pn))
         patched_cves.add(ca)
 


### PR DESCRIPTION
Scarthgap started a process of migrating from CVE_CHECK_IGNORE to
CVE_STATUS.  CVE_STATUS is a flagsdict rather than a simple variable,
which has keys of the CVE mapped to a status string.

Whinlatter started emitting a warning for deprecation of
CVE_CHECK_IGNORE.  Rework the use of CVE_CHECK_IGNORE and
CVE_CHECK_WHITELIST to both be backward compatible and without
the deprecation warnings.

```
WARNING: CVE_CHECK_IGNORE is deprecated in favor of CVE_STATUS
```
